### PR TITLE
Only disable data streams for the target input

### DIFF
--- a/fleet_integrations/system_application_winlog/module.tf.json
+++ b/fleet_integrations/system_application_winlog/module.tf.json
@@ -66,22 +66,8 @@
       "agent_policy_id": "${var.fleet_agent_policy_id}",
       "all_data_streams": [
         "application",
-        "auth",
-        "core",
-        "cpu",
-        "diskio",
-        "filesystem",
-        "fsstat",
-        "load",
-        "memory",
-        "network",
-        "process",
-        "process_summary",
         "security",
-        "socket_summary",
-        "syslog",
-        "system",
-        "uptime"
+        "system"
       ],
       "data_stream": "application",
       "data_stream_variables_json": "${jsonencode({\n  event_id = var.event_id\n  ignore_older = var.ignore_older\n  language = var.language\n  preserve_original_event = var.preserve_original_event\n  processors = var.processors_yaml\n  tags = var.tags\n})}",

--- a/fleet_integrations/system_security_winlog/module.tf.json
+++ b/fleet_integrations/system_security_winlog/module.tf.json
@@ -66,22 +66,8 @@
       "agent_policy_id": "${var.fleet_agent_policy_id}",
       "all_data_streams": [
         "application",
-        "auth",
-        "core",
-        "cpu",
-        "diskio",
-        "filesystem",
-        "fsstat",
-        "load",
-        "memory",
-        "network",
-        "process",
-        "process_summary",
         "security",
-        "socket_summary",
-        "syslog",
-        "system",
-        "uptime"
+        "system"
       ],
       "data_stream": "security",
       "data_stream_variables_json": "${jsonencode({\n  event_id = var.event_id\n  ignore_older = var.ignore_older\n  language = var.language\n  preserve_original_event = var.preserve_original_event\n  processors = var.processors_yaml\n  tags = var.tags\n})}",

--- a/fleet_integrations/windows_powershell_operational_winlog/module.tf.json
+++ b/fleet_integrations/windows_powershell_operational_winlog/module.tf.json
@@ -67,10 +67,8 @@
       "agent_policy_id": "${var.fleet_agent_policy_id}",
       "all_data_streams": [
         "forwarded",
-        "perfmon",
         "powershell",
         "powershell_operational",
-        "service",
         "sysmon_operational"
       ],
       "data_stream": "powershell_operational",

--- a/fleet_integrations/windows_powershell_winlog/module.tf.json
+++ b/fleet_integrations/windows_powershell_winlog/module.tf.json
@@ -67,10 +67,8 @@
       "agent_policy_id": "${var.fleet_agent_policy_id}",
       "all_data_streams": [
         "forwarded",
-        "perfmon",
         "powershell",
         "powershell_operational",
-        "service",
         "sysmon_operational"
       ],
       "data_stream": "powershell",

--- a/fleet_integrations/windows_sysmon_operational_winlog/module.tf.json
+++ b/fleet_integrations/windows_sysmon_operational_winlog/module.tf.json
@@ -66,10 +66,8 @@
       "agent_policy_id": "${var.fleet_agent_policy_id}",
       "all_data_streams": [
         "forwarded",
-        "perfmon",
         "powershell",
         "powershell_operational",
-        "service",
         "sysmon_operational"
       ],
       "data_stream": "sysmon_operational",


### PR DESCRIPTION
This is a partial fix for #7. Likely it still needs to disable the other data streams contained the policy template.

Fixes #7