### PR TITLE
fleet-module-generator - fail on error

### DIFF
--- a/fleet-terraform-generator/docs/fleet-terraform-generator_generate_batch.md
+++ b/fleet-terraform-generator/docs/fleet-terraform-generator_generate_batch.md
@@ -9,7 +9,8 @@ fleet-terraform-generator generate batch [flags]
 ### Options
 
 ```
-  -h, --help   help for batch
+      --continue-on-error   Continue on errors related to reading package specifications.
+  -h, --help                help for batch
 ```
 
 ### Options inherited from parent commands

--- a/fleet-terraform-generator/docs/fleet-terraform-generator_list.md
+++ b/fleet-terraform-generator/docs/fleet-terraform-generator_list.md
@@ -9,6 +9,7 @@ fleet-terraform-generator list [flags]
 ### Options
 
 ```
+      --continue-on-error     Continue on errors related to reading package specifications.
   -h, --help                  help for list
       --packages-dir string   Directory containing Fleet packages.
 ```

--- a/fleet-terraform-generator/internal/cmd/generate.go
+++ b/fleet-terraform-generator/internal/cmd/generate.go
@@ -37,6 +37,7 @@ const (
 	generateInputFlagName                   = "input"
 	generateOutputPathFlagName              = "out"
 	generateIgnoreVariableShadowingFlagName = "ignore-var-shadow"
+	generateContinueOnErrorFlagName         = "continue-on-error"
 )
 
 func GenerateCmd() *cobra.Command {
@@ -70,6 +71,8 @@ func GenerateCmd() *cobra.Command {
 		RunE:  generateBatchRunE,
 	}
 	cmd.AddCommand(batchCmd)
+
+	batchCmd.PersistentFlags().Bool(generateContinueOnErrorFlagName, false, "Continue on errors related to reading package specifications.")
 
 	return cmd
 }
@@ -144,7 +147,12 @@ func generateBatchRunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	specs, err := module.List(pkgsDir)
+	continueOnError, err := cmd.Flags().GetBool(generateContinueOnErrorFlagName)
+	if err != nil {
+		return err
+	}
+
+	specs, err := module.List(pkgsDir, continueOnError)
 	if err != nil {
 		return err
 	}

--- a/fleet-terraform-generator/internal/cmd/list.go
+++ b/fleet-terraform-generator/internal/cmd/list.go
@@ -37,6 +37,9 @@ func ListCmd() *cobra.Command {
 	}
 	cmd.Flags().String(packagesDirectoryFlagName, "", "Directory containing Fleet packages.")
 	must(cmd.MarkFlagRequired(packagesDirectoryFlagName))
+
+	cmd.PersistentFlags().Bool(generateContinueOnErrorFlagName, false, "Continue on errors related to reading package specifications.")
+
 	return cmd
 }
 
@@ -45,8 +48,12 @@ func listRunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	continueOnError, err := cmd.Flags().GetBool(generateContinueOnErrorFlagName)
+	if err != nil {
+		return err
+	}
 
-	moduleSpecifiers, err := module.List(pkgsDir)
+	moduleSpecifiers, err := module.List(pkgsDir, continueOnError)
 	if err != nil {
 		return err
 	}

--- a/fleet-terraform-generator/internal/module/list.go
+++ b/fleet-terraform-generator/internal/module/list.go
@@ -76,14 +76,17 @@ func (l Specifiers) Filter(globs ...string) (Specifiers, error) {
 	return out, nil
 }
 
-func List(dir string) (Specifiers, error) {
+func List(dir string, continueOnError bool) (Specifiers, error) {
 	var result []Specifier
 
 	// Generate the product of policy_template x data_stream x input.
 	err := walkPackages(dir, func(pkg *fleetpkg.Integration, err error) error {
 		if err != nil {
-			log.Println("[WARN] Ignoring package:", err)
-			return nil
+			if continueOnError {
+				log.Println("[WARN] Ignoring package:", err)
+				return nil
+			}
+			return err
 		}
 
 		if pkg.Manifest.Type == "input" {


### PR DESCRIPTION
Change the default behavior to fail on an error while reading package specifications. To keep the old behavior you may set `--continue-on-error`.