### PR TITLE
Add elasticstack_fleet_integration to fleet_package_policy

### DIFF
--- a/examples/github/main.tf
+++ b/examples/github/main.tf
@@ -10,6 +10,15 @@ provider "restapi" {
   }
 }
 
+provider "elasticstack" {
+  kibana {
+    username  = var.kibana_username
+    password  = var.kibana_password
+    insecure  = var.kibana_insecure
+    endpoints = [var.kibana_url]
+  }
+}
+
 // Create a new empty Fleet agent policy that will be used for running the GitHub integration.
 module "agent_policy_github" {
   source      = "../../fleet_agent_policy"

--- a/examples/github/versions.tf
+++ b/examples/github/versions.tf
@@ -1,9 +1,13 @@
 terraform {
   required_version = ">= 1.4"
   required_providers {
+    elasticstack = {
+      source  = "elastic/elasticstack"
+      version = "~> 0.11"
+    }
     restapi = {
       source  = "Mastercard/restapi"
-      version = "~> 1.18.0"
+      version = "~> 1.18"
     }
   }
 }

--- a/fleet_agent_policy/providers.tf
+++ b/fleet_agent_policy/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     elasticstack = {
       source  = "elastic/elasticstack"
-      version = "~> 0.6.2"
+      version = ">= 0.11.0"
     }
   }
 }

--- a/fleet_output/providers.tf
+++ b/fleet_output/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     elasticstack = {
       source  = "elastic/elasticstack"
-      version = "~> 0.6.2"
+      version = ">= 0.11.0"
     }
   }
 }

--- a/fleet_package_policy/main.tf
+++ b/fleet_package_policy/main.tf
@@ -25,6 +25,15 @@ locals {
   }
 }
 
+// Control the version of the installed package. Fleet will not allow
+// downgrades while there are package policies using the package. Only one
+// version of any package may be installed at one time.
+resource "elasticstack_fleet_integration" "assets" {
+  name    = var.package_name
+  version = var.package_version
+  force   = true
+}
+
 resource "restapi_object" "package_policy" {
   path         = "/api/fleet/package_policies"
   id_attribute = "item/id"
@@ -53,4 +62,8 @@ resource "restapi_object" "package_policy" {
       }
     }, local.disabled_inputs_config)
   })
+
+  depends_on = [
+    elasticstack_fleet_integration.assets,
+  ]
 }

--- a/fleet_package_policy/providers.tf
+++ b/fleet_package_policy/providers.tf
@@ -1,5 +1,9 @@
 terraform {
   required_providers {
+    elasticstack = {
+      source  = "elastic/elasticstack"
+      version = ">= 0.11.0"
+    }
     restapi = {
       source  = "Mastercard/restapi"
       version = ">= 1.18.0"

--- a/fleet_server_host/providers.tf
+++ b/fleet_server_host/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     elasticstack = {
       source  = "elastic/elasticstack"
-      version = "~> 0.6.2"
+      version = ">= 0.11.0"
     }
   }
 }


### PR DESCRIPTION
Control version of the installed package by using elasticstack_fleet_integration.

Previously the version was honored only the first time that a package was installed. With this change now the package version will be upgraded.