### PR TITLE
fleet_package_policy - add skip_destroy=true

### DIFF
--- a/.changelog/35.txt
+++ b/.changelog/35.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+fleet_package_policy - Add `skip_destroy = true` to elasticstack_fleet_integration to avoid trying to uninstall the package while it might be in use by another package policy.
+```

--- a/fleet_package_policy/main.tf
+++ b/fleet_package_policy/main.tf
@@ -29,9 +29,10 @@ locals {
 // downgrades while there are package policies using the package. Only one
 // version of any package may be installed at one time.
 resource "elasticstack_fleet_integration" "assets" {
-  name    = var.package_name
-  version = var.package_version
-  force   = true
+  name         = var.package_name
+  version      = var.package_version
+  force        = true
+  skip_destroy = true
 }
 
 resource "restapi_object" "package_policy" {


### PR DESCRIPTION
Add skip_destroy = true for the elasticstack_fleet_integration. This will leave the package installed, but avoids attempts to remove the package while it might be used by another package policy (which is likely given the model used in this module).