### PR TITLE
release-notes - fix last-release command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         id: release-notes
         continue-on-error: true
         run: |
-          cd tools && go install ./cmd/release-notes && cd -
+          go install -C tools ./cmd/release-notes
           
           last_release="$(release-notes last-release)"
           


### PR DESCRIPTION
Fix last-release command. It was randomly returning a release tag.

Improve the command to return the latest tag on the current branch.

Validate the CLI commands.

And use `go run -C <dir>` instead of using `cd <dir>`.