### PR TITLE
bugfix - handle reserved word 'provider'

### DIFF
--- a/.changelog/44.txt
+++ b/.changelog/44.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+fleet-terraform-generator: Add handling for the reserved word `provider` within Terraform modules.
+```

--- a/fleet_integration/aws_bedrock.invocation.aws-s3/README.md
+++ b/fleet_integration/aws_bedrock.invocation.aws-s3/README.md
@@ -49,7 +49,7 @@ No resources.
 | <a name="input_preserve_duplicate_custom_fields"></a> [preserve\_duplicate\_custom\_fields](#input\_preserve\_duplicate\_custom\_fields) | Preserve Bedrock fields that were copied to Elastic Common Schema (ECS) fields. | `bool` | `false` | no |
 | <a name="input_preserve_original_event"></a> [preserve\_original\_event](#input\_preserve\_original\_event) | Preserves a raw copy of the original event, added to the field `event.original` | `bool` | `false` | no |
 | <a name="input_processors_yaml"></a> [processors\_yaml](#input\_processors\_yaml) | Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details. | `string` | `null` | no |
-| <a name="input_provider"></a> [provider](#input\_provider) | Name of the 3rd party S3 bucket provider like backblaze or GCP. | `string` | `null` | no |
+| <a name="input_provider_name"></a> [provider\_name](#input\_provider\_name) | Name of the 3rd party S3 bucket provider like backblaze or GCP. | `string` | `null` | no |
 | <a name="input_proxy_url"></a> [proxy\_url](#input\_proxy\_url) | URL to proxy connections in the form of http\[s\]://<user>:<password>@<server name/ip>:<port> | `string` | `null` | no |
 | <a name="input_queue_url"></a> [queue\_url](#input\_queue\_url) | URL of the AWS SQS queue that messages will be received from. | `string` | `null` | no |
 | <a name="input_role_arn"></a> [role\_arn](#input\_role\_arn) | n/a | `string` | `null` | no |

--- a/fleet_integration/aws_bedrock.invocation.aws-s3/module.tf.json
+++ b/fleet_integration/aws_bedrock.invocation.aws-s3/module.tf.json
@@ -140,7 +140,7 @@
       "description": "Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.\n",
       "default": null
     },
-    "provider": {
+    "provider_name": {
       "type": "string",
       "description": "Name of the 3rd party S3 bucket provider like backblaze or GCP.",
       "default": null
@@ -214,7 +214,7 @@
         "aws_bedrock-aws-cloudwatch"
       ],
       "data_stream": "invocation",
-      "data_stream_variables_json": "${jsonencode({\n  api_timeout = var.api_timeout\n  bucket_arn = var.bucket_arn\n  bucket_list_interval = var.bucket_list_interval\n  bucket_list_prefix = var.bucket_list_prefix\n  buffer_size = var.buffer_size\n  content_type = var.content_type\n  encoding = var.encoding\n  expand_event_list_from_field = var.expand_event_list_from_field\n  file_selectors = var.file_selectors_yaml\n  fips_enabled = var.fips_enabled\n  include_s3_metadata = var.include_s3_metadata\n  max_bytes = var.max_bytes\n  max_number_of_messages = var.max_number_of_messages\n  non_aws_bucket_name = var.non_aws_bucket_name\n  number_of_workers = var.number_of_workers\n  path_style = var.path_style\n  preserve_duplicate_custom_fields = var.preserve_duplicate_custom_fields\n  preserve_original_event = var.preserve_original_event\n  processors = var.processors_yaml\n  provider = var.provider\n  queue_url = var.queue_url\n  \"sqs.max_receive_count\" = var.sqs_max_receive_count\n  \"sqs.wait_time\" = var.sqs_wait_time\n  tags = var.tags\n  visibility_timeout = var.visibility_timeout\n})}",
+      "data_stream_variables_json": "${jsonencode({\n  api_timeout = var.api_timeout\n  bucket_arn = var.bucket_arn\n  bucket_list_interval = var.bucket_list_interval\n  bucket_list_prefix = var.bucket_list_prefix\n  buffer_size = var.buffer_size\n  content_type = var.content_type\n  encoding = var.encoding\n  expand_event_list_from_field = var.expand_event_list_from_field\n  file_selectors = var.file_selectors_yaml\n  fips_enabled = var.fips_enabled\n  include_s3_metadata = var.include_s3_metadata\n  max_bytes = var.max_bytes\n  max_number_of_messages = var.max_number_of_messages\n  non_aws_bucket_name = var.non_aws_bucket_name\n  number_of_workers = var.number_of_workers\n  path_style = var.path_style\n  preserve_duplicate_custom_fields = var.preserve_duplicate_custom_fields\n  preserve_original_event = var.preserve_original_event\n  processors = var.processors_yaml\n  provider = var.provider_name\n  queue_url = var.queue_url\n  \"sqs.max_receive_count\" = var.sqs_max_receive_count\n  \"sqs.wait_time\" = var.sqs_wait_time\n  tags = var.tags\n  visibility_timeout = var.visibility_timeout\n})}",
       "description": "${var.fleet_package_policy_description}",
       "input_type": "aws-s3",
       "namespace": "${var.fleet_data_stream_namespace}",

--- a/fleet_integration/aws_logs.generic.aws-s3/README.md
+++ b/fleet_integration/aws_logs.generic.aws-s3/README.md
@@ -52,7 +52,7 @@ No resources.
 | <a name="input_pipeline"></a> [pipeline](#input\_pipeline) | The Ingest Node pipeline ID to be used by the integration. | `string` | `null` | no |
 | <a name="input_preserve_original_event"></a> [preserve\_original\_event](#input\_preserve\_original\_event) | Preserves a raw copy of the original event, added to the field `event.original` | `bool` | `false` | no |
 | <a name="input_processors_yaml"></a> [processors\_yaml](#input\_processors\_yaml) | Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details. | `string` | `null` | no |
-| <a name="input_provider"></a> [provider](#input\_provider) | Name of the 3rd party S3 bucket provider like backblaze or GCP. | `string` | `null` | no |
+| <a name="input_provider_name"></a> [provider\_name](#input\_provider\_name) | Name of the 3rd party S3 bucket provider like backblaze or GCP. | `string` | `null` | no |
 | <a name="input_proxy_url"></a> [proxy\_url](#input\_proxy\_url) | URL to proxy connections in the form of http\[s\]://<user>:<password>@<server name/ip>:<port> | `string` | `null` | no |
 | <a name="input_queue_url"></a> [queue\_url](#input\_queue\_url) | URL of the AWS SQS queue that messages will be received from. | `string` | `null` | no |
 | <a name="input_role_arn"></a> [role\_arn](#input\_role\_arn) | n/a | `string` | `null` | no |

--- a/fleet_integration/aws_logs.generic.aws-s3/module.tf.json
+++ b/fleet_integration/aws_logs.generic.aws-s3/module.tf.json
@@ -156,7 +156,7 @@
       "description": "Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.\n",
       "default": null
     },
-    "provider": {
+    "provider_name": {
       "type": "string",
       "description": "Name of the 3rd party S3 bucket provider like backblaze or GCP.",
       "default": null
@@ -230,7 +230,7 @@
         "aws_logs-aws-cloudwatch"
       ],
       "data_stream": "generic",
-      "data_stream_variables_json": "${jsonencode({\n  api_timeout = var.api_timeout\n  bucket_arn = var.bucket_arn\n  bucket_list_interval = var.bucket_list_interval\n  bucket_list_prefix = var.bucket_list_prefix\n  buffer_size = var.buffer_size\n  content_type = var.content_type\n  custom = var.custom_yaml\n  \"data_stream.dataset\" = var.data_stream_dataset\n  encoding = var.encoding\n  expand_event_list_from_field = var.expand_event_list_from_field\n  file_selectors = var.file_selectors_yaml\n  fips_enabled = var.fips_enabled\n  include_s3_metadata = var.include_s3_metadata\n  max_bytes = var.max_bytes\n  max_number_of_messages = var.max_number_of_messages\n  non_aws_bucket_name = var.non_aws_bucket_name\n  number_of_workers = var.number_of_workers\n  parsers = var.parsers_yaml\n  path_style = var.path_style\n  pipeline = var.pipeline\n  preserve_original_event = var.preserve_original_event\n  processors = var.processors_yaml\n  provider = var.provider\n  queue_url = var.queue_url\n  \"sqs.max_receive_count\" = var.sqs_max_receive_count\n  \"sqs.wait_time\" = var.sqs_wait_time\n  tags = var.tags\n  visibility_timeout = var.visibility_timeout\n})}",
+      "data_stream_variables_json": "${jsonencode({\n  api_timeout = var.api_timeout\n  bucket_arn = var.bucket_arn\n  bucket_list_interval = var.bucket_list_interval\n  bucket_list_prefix = var.bucket_list_prefix\n  buffer_size = var.buffer_size\n  content_type = var.content_type\n  custom = var.custom_yaml\n  \"data_stream.dataset\" = var.data_stream_dataset\n  encoding = var.encoding\n  expand_event_list_from_field = var.expand_event_list_from_field\n  file_selectors = var.file_selectors_yaml\n  fips_enabled = var.fips_enabled\n  include_s3_metadata = var.include_s3_metadata\n  max_bytes = var.max_bytes\n  max_number_of_messages = var.max_number_of_messages\n  non_aws_bucket_name = var.non_aws_bucket_name\n  number_of_workers = var.number_of_workers\n  parsers = var.parsers_yaml\n  path_style = var.path_style\n  pipeline = var.pipeline\n  preserve_original_event = var.preserve_original_event\n  processors = var.processors_yaml\n  provider = var.provider_name\n  queue_url = var.queue_url\n  \"sqs.max_receive_count\" = var.sqs_max_receive_count\n  \"sqs.wait_time\" = var.sqs_wait_time\n  tags = var.tags\n  visibility_timeout = var.visibility_timeout\n})}",
       "description": "${var.fleet_package_policy_description}",
       "input_type": "aws-s3",
       "namespace": "${var.fleet_data_stream_namespace}",

--- a/tools/internal/module/generate.go
+++ b/tools/internal/module/generate.go
@@ -322,9 +322,12 @@ func addVariable(v fleetpkg.Var, m map[string]moduleVariable, ignoreShadowing bo
 		name += "_yaml"
 	}
 
-	// 'providers' is a reserved word in Terraform.
-	if name == "providers" {
+	// Handle reserved words in terraform.
+	switch name {
+	case "providers":
 		name = "providers_names"
+	case "provider":
+		name = "provider_name"
 	}
 
 	// Don't allow variables shadowing. See https://github.com/elastic/package-spec/issues/421


### PR DESCRIPTION
If a Fleet module contains a variable named 'provider' then expose it as 'provider_name' in the Terraform module.

This assumes that no Fleet module use both 'provider' and 'provider_name'.

Fixes errors like

    Error: Invalid variable name

    The variable name "provider" is reserved due to its special meaning inside module blocks.