### PR TITLE
feat: support package_version = "latest"

### DIFF
--- a/.changelog/117.txt
+++ b/.changelog/117.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+fleet_package_policy and generated modules - Support installing the latest package version by setting `package_version = "latest"` (`fleet_package_version = "latest"` in generated modules). The version is resolved from the package registry at plan time. A new `prerelease` variable (`fleet_package_prerelease` in generated modules) controls whether prerelease versions are considered during resolution.
+```

--- a/examples/github/main.tf
+++ b/examples/github/main.tf
@@ -30,6 +30,7 @@ module "agent_policy_github" {
 module "integration_github_issues" {
   source                = "../../fleet_integration/github.issues.httpjson"
   fleet_agent_policy_id = module.agent_policy_github.id
+  fleet_package_version = "latest"
   access_token          = var.github_token
   owner                 = "elastic"
 }

--- a/fleet_package_policy/.readme.md
+++ b/fleet_package_policy/.readme.md
@@ -3,6 +3,44 @@
 This module installs the Fleet package's assets, creates a package policy, and
 associates that package policy to an existing agent policy.
 
+## Package Version
+
+The `package_version` parameter controls which version of the package is
+installed. It supports two modes.
+
+### Pinned Version (Default)
+
+Set `package_version` to a semantic version (e.g. `1.2.3`) to install exactly
+that version. This is deterministic: the same configuration always produces the
+same result, and upgrades only happen when the pinned version is changed.
+
+Note that Kibana Fleet rejects installing a pinned version when a newer version
+exists in the package registry, returning HTTP 400 "out-of-date and cannot be
+installed or updated" unless `force = true` is used. This means pinned versions
+can break over time as newer package versions are published to the registry.
+
+### Latest Version
+
+Set `package_version = "latest"` to resolve the latest available version of the
+package from the package registry at plan time. Resolution uses the
+`elasticstack_fleet_integration` data source, so the concrete version is
+determined during `terraform plan` and recorded in state. Each new release of
+the package in the registry shows up as an in-place upgrade of the package and
+package policy on the next plan.
+
+This mode avoids the "out-of-date" rejection described above without resorting
+to `force = true` and its destructive reinstallation behavior. The trade-off is
+that plans are no longer fully deterministic because the resolved version
+depends on the registry contents at plan time.
+
+### Prerelease Versions
+
+The `prerelease` parameter controls whether prerelease package versions are
+considered when resolving `package_version = "latest"`. Packages with versions
+below 1.0.0 are treated as prerelease by semver, so `prerelease = true` is
+required to resolve "latest" for those packages. It has no effect when
+`package_version` is pinned.
+
 ## Force Reinstallation Parameter
 
 ### Overview

--- a/fleet_package_policy/README.md
+++ b/fleet_package_policy/README.md
@@ -4,6 +4,44 @@
 This module installs the Fleet package's assets, creates a package policy, and
 associates that package policy to an existing agent policy.
 
+## Package Version
+
+The `package_version` parameter controls which version of the package is
+installed. It supports two modes.
+
+### Pinned Version (Default)
+
+Set `package_version` to a semantic version (e.g. `1.2.3`) to install exactly
+that version. This is deterministic: the same configuration always produces the
+same result, and upgrades only happen when the pinned version is changed.
+
+Note that Kibana Fleet rejects installing a pinned version when a newer version
+exists in the package registry, returning HTTP 400 "out-of-date and cannot be
+installed or updated" unless `force = true` is used. This means pinned versions
+can break over time as newer package versions are published to the registry.
+
+### Latest Version
+
+Set `package_version = "latest"` to resolve the latest available version of the
+package from the package registry at plan time. Resolution uses the
+`elasticstack_fleet_integration` data source, so the concrete version is
+determined during `terraform plan` and recorded in state. Each new release of
+the package in the registry shows up as an in-place upgrade of the package and
+package policy on the next plan.
+
+This mode avoids the "out-of-date" rejection described above without resorting
+to `force = true` and its destructive reinstallation behavior. The trade-off is
+that plans are no longer fully deterministic because the resolved version
+depends on the registry contents at plan time.
+
+### Prerelease Versions
+
+The `prerelease` parameter controls whether prerelease package versions are
+considered when resolving `package_version = "latest"`. Packages with versions
+below 1.0.0 are treated as prerelease by semver, so `prerelease = true` is
+required to resolve "latest" for those packages. It has no effect when
+`package_version` is pinned.
+
 ## Force Reinstallation Parameter
 
 ### Overview
@@ -158,6 +196,7 @@ No modules.
 |------|------|
 | [elasticstack_fleet_integration.assets](https://registry.terraform.io/providers/elastic/elasticstack/latest/docs/resources/fleet_integration) | resource |
 | [restapi_object.package_policy](https://registry.terraform.io/providers/Mastercard/restapi/latest/docs/resources/object) | resource |
+| [elasticstack_fleet_integration.latest](https://registry.terraform.io/providers/elastic/elasticstack/latest/docs/data-sources/fleet_integration) | data source |
 
 ## Inputs
 
@@ -176,8 +215,9 @@ No modules.
 | <a name="input_package_name"></a> [package\_name](#input\_package\_name) | Name of the Fleet package to install (e.g. ti\_recordedfuture). | `string` | n/a | yes |
 | <a name="input_package_policy_name"></a> [package\_policy\_name](#input\_package\_policy\_name) | Name of the package policy. Defaults to "{package\_name}-{namespace}." | `any` | `null` | no |
 | <a name="input_package_variables_json"></a> [package\_variables\_json](#input\_package\_variables\_json) | JSON encoded package level variables that are shared by each stream. | `string` | `"{}"` | no |
-| <a name="input_package_version"></a> [package\_version](#input\_package\_version) | Package version. | `string` | n/a | yes |
+| <a name="input_package_version"></a> [package\_version](#input\_package\_version) | Package version. Use "latest" to resolve the latest available version from the package registry at plan time. | `string` | n/a | yes |
 | <a name="input_policy_template"></a> [policy\_template](#input\_policy\_template) | Name of the policy template (see the integration's manifest.yml). | `string` | n/a | yes |
+| <a name="input_prerelease"></a> [prerelease](#input\_prerelease) | Include prerelease package versions when resolving package\_version = "latest".<br>Required for packages whose versions are below 1.0.0 (semver treats 0.x as<br>prerelease). Has no effect when package\_version is pinned. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/fleet_package_policy/main.tf
+++ b/fleet_package_policy/main.tf
@@ -25,12 +25,28 @@ locals {
   }
 }
 
+// Resolve the latest available version of the package from the package
+// registry when package_version is "latest". Resolution happens at plan time.
+data "elasticstack_fleet_integration" "latest" {
+  count      = var.package_version == "latest" ? 1 : 0
+  name       = var.package_name
+  prerelease = var.prerelease
+}
+
+locals {
+  effective_package_version = (
+    var.package_version == "latest"
+    ? data.elasticstack_fleet_integration.latest[0].version
+    : var.package_version
+  )
+}
+
 // Control the version of the installed package. Fleet will not allow
 // downgrades while there are package policies using the package. Only one
 // version of any package may be installed at one time.
 resource "elasticstack_fleet_integration" "assets" {
   name         = var.package_name
-  version      = var.package_version
+  version      = local.effective_package_version
   force        = var.force
   skip_destroy = true
 }
@@ -43,7 +59,7 @@ resource "restapi_object" "package_policy" {
     policy_id = var.agent_policy_id
     package = {
       name    = var.package_name
-      version = var.package_version
+      version = local.effective_package_version
     }
     name        = local.policy_name
     namespace   = var.namespace

--- a/fleet_package_policy/variables.tf
+++ b/fleet_package_policy/variables.tf
@@ -14,11 +14,11 @@ variable "package_name" {
 }
 
 variable "package_version" {
-  description = "Package version."
+  description = "Package version. Use \"latest\" to resolve the latest available version from the package registry at plan time."
   type        = string
   validation {
-    condition     = can(regex("^\\d+\\.\\d+\\.\\d+", var.package_version))
-    error_message = "Invalid package_version version."
+    condition     = var.package_version == "latest" || can(regex("^\\d+\\.\\d+\\.\\d+", var.package_version))
+    error_message = "package_version must be a semantic version (e.g. 1.2.3) or the literal \"latest\"."
   }
 }
 
@@ -110,3 +110,12 @@ variable "force" {
   default     = false
 }
 
+variable "prerelease" {
+  description = <<-EOT
+    Include prerelease package versions when resolving package_version = "latest".
+    Required for packages whose versions are below 1.0.0 (semver treats 0.x as
+    prerelease). Has no effect when package_version is pinned.
+  EOT
+  type        = bool
+  default     = false
+}

--- a/tools/internal/module/generate.go
+++ b/tools/internal/module/generate.go
@@ -168,8 +168,15 @@ func Generate(path, policyTemplateName, dataStreamName, inputName string, ignore
 		"fleet_package_version": {
 			Terraform: terraform.Variable{
 				Type:        "string",
-				Description: "Version of the " + manifest.Name + " package to use.",
+				Description: "Version of the " + manifest.Name + " package to use. Use \"latest\" to resolve the latest available version from the package registry at plan time.",
 				Default:     &terraform.NullableValue{Value: manifest.Version},
+			},
+		},
+		"fleet_package_prerelease": {
+			Terraform: terraform.Variable{
+				Type:        "bool",
+				Description: "Include prerelease package versions when fleet_package_version is \"latest\". Required for packages below version 1.0.0.",
+				Default:     &terraform.NullableValue{Value: strings.HasPrefix(manifest.Version, "0.")},
 			},
 		},
 	}
@@ -285,6 +292,7 @@ func Generate(path, policyTemplateName, dataStreamName, inputName string, ignore
 					AllDataStreams:          dataStreamsForInput,
 					AllPolicyTemplateInputs: allPolicyTemplateInputs,
 					Force:                   "${var.fleet_package_policy_force}",
+					Prerelease:              "${var.fleet_package_prerelease}",
 				}),
 			},
 		},
@@ -445,6 +453,7 @@ type FleetPackagePolicyModule struct {
 	AllDataStreams          []string `json:"all_data_streams"`
 	AllPolicyTemplateInputs []string `json:"all_policy_template_inputs"` // All policy_template + input combos.
 	Force                   string   `json:"force,omitempty"`
+	Prerelease              string   `json:"prerelease,omitempty"`
 }
 
 func toMap(v any) map[string]any {


### PR DESCRIPTION
## Summary

This adds a "latest" package-version mode to `fleet_package_policy` and all generated modules.

- `fleet_package_policy` now accepts `package_version = "latest"` (generated modules: `fleet_package_version = "latest"`). The latest available version of the package is resolved from the package registry at plan time using the `elasticstack_fleet_integration` data source (available since provider v0.11.0, which the module already requires). Each new registry release shows up as an in-place upgrade on the next plan.
- New `prerelease` variable (generated modules: `fleet_package_prerelease`) controls whether prerelease versions are considered during "latest" resolution. It defaults to `true` in generated modules for packages below version 1.0.0, because semver treats 0.x releases as prerelease. It has no effect when the version is pinned.
- Pinned semantic versions remain the default and are unchanged.
- The github example now sets `fleet_package_version = "latest"` so `terraform validate` exercises the new path.

## Motivation

Kibana Fleet rejects installing a pinned package version when a newer version exists in the registry (HTTP 400 "out-of-date and cannot be installed or updated") unless `force = true` is used. Using `"latest"` avoids that failure mode without the destructive reinstall behavior that `force = true` entails (deleted/recreated Kibana assets, removed transforms and destination indices).

## Regeneration

All modules were regenerated from elastic/integrations@7aaaab24bc57b593d2044a1a16435eb120fa28b8. Besides the new `fleet_package_prerelease` variable, this brings incidental default version bumps and three new modules from newer manifests matching the existing selectors: `crowdstrike.identity_protection_assessment.cel`, `crowdstrike.identity_protection_timeline.cel`, and `sentinel_one.unified_alert.cel`.

## Validation

- `go build ./... && go test ./...` in tools/ passes.
- `make all` (fmt + modules + docs + validate) passes; `terraform init && terraform validate` in examples/github succeeds with the "latest" path enabled.